### PR TITLE
fix(android): video render failed after call reset

### DIFF
--- a/android/ijkplayer/ijkplayer-java/src/main/java/tv/danmaku/ijk/media/player/IjkMediaPlayer.java
+++ b/android/ijkplayer/ijkplayer-java/src/main/java/tv/danmaku/ijk/media/player/IjkMediaPlayer.java
@@ -774,6 +774,11 @@ public final class IjkMediaPlayer extends AbstractMediaPlayer {
 
         mVideoWidth = 0;
         mVideoHeight = 0;
+
+        if (isAmcUsingGlesRender()){
+            mMediaCodecSurface = new MediaCodecSurface();
+            _setMediaCodecSurface(mMediaCodecSurface);
+        }
     }
 
     private native void _reset();

--- a/ijkmedia/ijksdl/android/ijksdl_vout_android_nativewindow.c
+++ b/ijkmedia/ijksdl/android/ijksdl_vout_android_nativewindow.c
@@ -121,12 +121,7 @@ static void func_free_context_l(SDL_Vout *vout)
 
     SDL_Vout_Opaque *opaque = vout->opaque;
     if (opaque) {
-        IJK_EGL_freep(&opaque->egl);
-
-        if (opaque->native_window) {
-            ANativeWindow_release(opaque->native_window);
-            opaque->native_window = NULL;
-        }
+        IJK_EGL_terminate(opaque->egl);
     }
 }
 


### PR DESCRIPTION
just release gl context, keep native window.
if use amc gles, reset mediacodec surface

fix https://github.com/befovy/fijkplayer/issues/226